### PR TITLE
Address vulnerabilities identified by dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ amqp==5.0.9
     # via kombu
 anyio==3.2.1
     # via httpcore
-apache-airflow[amazon,celery,crypto,flask_oauth,postgres,sentry,slack]==2.2.2
+apache-airflow[amazon,celery,crypto,flask_oauth,postgres,sentry,slack]==2.2.4
     # via
     #   -r requirements.in
     #   apache-airflow-providers-amazon


### PR DESCRIPTION
## Change description

Addresses below vulnerabilities identified by dependabot.

- In Apache Airflow, prior to version 2.2.4, some example DAGs did not properly
sanitize user-provided params, making them susceptible to OS Command Injection
from the web UI.

- It was discovered that the "Trigger DAG with config" screen was susceptible
to XSS attacks via the origin query argument. This issue affects
Apache Airflow versions 2.2.3 and below.